### PR TITLE
Update for React-Native 0.42

### DIFF
--- a/android/src/main/java/com/helpkang/kakaologin/KakaoLoginModule.java
+++ b/android/src/main/java/com/helpkang/kakaologin/KakaoLoginModule.java
@@ -1,5 +1,6 @@
 package com.helpkang.kakaologin;
 
+import android.app.Activity;
 import android.content.Intent;
 
 import com.facebook.react.bridge.ActivityEventListener;
@@ -43,14 +44,12 @@ public class KakaoLoginModule extends ReactContextBaseJavaModule implements Acti
         this.rkl = new ReactKakaoLogin(reactContext);
     }
 
-
     @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (Session.getCurrentSession().handleActivityResult(requestCode, resultCode, data)){
+    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
+        if (Session.getCurrentSession().handleActivityResult(requestCode, resultCode, data)) {
             return;
         }
     }
-
 
     @Override
     public void onNewIntent(Intent intent) {


### PR DESCRIPTION
The method of `onActivityResult` need `Activity` argument over React-Native 0.41.   

- Reference: [React-Native 0.42](https://facebook.github.io/react-native/docs/native-modules-android.html#getting-activity-result-from-startactivityforresult)